### PR TITLE
Add function macro

### DIFF
--- a/src/common.inc
+++ b/src/common.inc
@@ -1,0 +1,22 @@
+.macro function __name
+.proc __name
+    pha
+    phx
+    phy
+    php
+    phd
+    tsc
+    tcd
+.endmacro
+
+.macro endFunction
+    tdc
+    tcs
+    pld
+    plp
+    ply
+    plx
+    pla
+    rts
+  .endproc
+.endmacro

--- a/src/main.asm
+++ b/src/main.asm
@@ -4,6 +4,8 @@
 ;----------------------------------------------------------------------------
 .setcpu "65816"
 
+.include "common.inc"
+
 .import InitRegs
 
 .segment "RODATA"


### PR DESCRIPTION
サブルーチンの定義のための macro を追加した。

サブルーチン呼び出し時のスタックポインタからの相対的なアドレスで、引数やローカル変数を参照することを想定している。